### PR TITLE
fix: create card default card template

### DIFF
--- a/src/constants/appConstants.ts
+++ b/src/constants/appConstants.ts
@@ -1,3 +1,5 @@
+export const DEFAULT_CARD_TEMPLATE = 1
+
 interface MenuDataType {
     title: string;
     link: string;

--- a/src/module/cards/cardSlice.ts
+++ b/src/module/cards/cardSlice.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { DEFAULT_CARD_TEMPLATE } from '@/constants/appConstants';
 import { CardBasicsSchema, CardBasicsType, CardState, ContentFormSchema, ContentFormSchemaType, DesignFormUpdateSchema, DesignFromSchemaType, InfosFormsUpdateSchema } from '@/module/cards/cardsType';
 import { PayloadAction, createSlice } from '@reduxjs/toolkit';
 import { ZodSchema } from 'zod';
@@ -55,7 +56,7 @@ export const initialState: CardState<string> = {
   cardInfos:
     { values: {}, errors: {} }
   ,
-  cardTemplate: "1"
+  cardTemplate: `${DEFAULT_CARD_TEMPLATE}`
 
 };
 

--- a/src/module/cards/cardsApi.ts
+++ b/src/module/cards/cardsApi.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_CARD_TEMPLATE } from "@/constants/appConstants";
 import { apiPaths } from "@/core/api/apiConstants";
 import { baseApi } from "@/core/api/apiQuery";
 import { PaginatedResponseType } from "@/core/types/responseTypes";
@@ -136,7 +137,7 @@ const cardsApi = baseApi.injectEndpoints({
           'card_design': {},
           'user': user,
           'title': title,
-          "card_template": 2
+          "card_template": `${DEFAULT_CARD_TEMPLATE}`
         }
         return {
           url: `${apiPaths.cardsUrl}`,


### PR DESCRIPTION
add default card template constant
use it on template id of cardState and create card api

## Summary by Sourcery

Bug Fixes:
- Fix the card template ID in the card state and create card API to use a default constant.